### PR TITLE
Use correct null check on tags collection

### DIFF
--- a/functions/TagWithCreator/run.ps1
+++ b/functions/TagWithCreator/run.ps1
@@ -30,7 +30,7 @@ foreach ($case in $ignore) {
 
 $tags = (Get-AzTag -ResourceId $resourceId).Properties
 
-if (!($tags.TagsProperty.ContainsKey('Creator')) -or ($null -eq $tags)) {
+if (($null -eq $tags.TagsProperty) -or !($tags.TagsProperty.ContainsKey('Creator')) ) {
     $tag = @{
         Creator = $caller
     }


### PR DESCRIPTION
When creating a resource without any other tags applied, $tags is not null, but $tags.TagsProperty is.  This leads to the error 'ERROR: You cannot call a method on a null-valued expression' at line 33. 